### PR TITLE
feat: include uplink, rumqtt and parseable

### DIFF
--- a/website/data/open-source/projects.yml
+++ b/website/data/open-source/projects.yml
@@ -8,6 +8,9 @@ Developer Productivity & Tools:
   - devtron-labs/devtron
   - skytable/skytable
   - ajeetdsouza/zoxide
+  - bytebeamio/rumqtt
+  - bytebeamio/uplink
+  - parseablehq/parseable
 
 Observability:
   - signoz/signoz


### PR DESCRIPTION
Some developer centric projects we have built in India :)

<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/india/blob/main/CONTRIBUTING.md>.

### Which change are you proposing?

  - [x] Adding/updating open source project/s
  - [ ] Adding/updating maintainer/s
  
---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Adding/updating open source project/s

- [x] The project was built in or receives significant contributions from India
- [x] The project has at least 100 stargazers

**Why should this open source project be featured?**

> rumqtt is an MQTT client library and an embeddable broker while uplink is a project built on top of rumqttc(the client library part of rumqtt) as a sidecar utility which runs on the edge and allows for remote control and data collection capabilities in IoT applications. Parseable on the other hand is a log collection and storage tool that is built to be cloud native. All of these are built in rust-lang too!

<!-- ⚠️ ... or this section ⚠️ -->
### Adding/updating maintainer/s

- [x] Maintainer's location on their GitHub profile indicates as India
- [x] Maintainer has approved this PR to be included on the website

**What open source project/s does the individual maintain?**

> I currently only maintain the rumqtt and uplink repos, while I am currently not associated directly with the maintenance of the parseable repo.

<!-- ⚠️ ... or this section ⚠️ -->
### Something that does not neatly fit into the binary options above

- [ ] My suggested edits are not about an existing page, or at least not a single one

> Please replace this line with an explanation of your proposed changes.

---

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**